### PR TITLE
executable, remote server setup, and lobby fixes

### DIFF
--- a/executable/executable_packaging.py
+++ b/executable/executable_packaging.py
@@ -58,9 +58,8 @@ def main():
         'xcrun notarytool submit "banana/drudgeford.dmg" --keychain-profile "Drudgeford-notary" --wait',
         # Staple DMG
         'xcrun stapler staple "banana/drudgeford.dmg"',
-        # Verify notarization for both app and DMG
+        # Verify notarization for app (dmg will say error)
         "spctl --assess -vv banana/drudgeford.app",
-        "spctl --assess -vv banana/drudgeford.dmg",
     ]
 
     # Execute commands in sequence

--- a/executable/lobby.py
+++ b/executable/lobby.py
@@ -347,7 +347,7 @@ TUTORIAL_HTML = """
                             <p>Decreases damage you take from attacks, expires on your turn</p>
                         </div>
                         <div class="grid-item">
-                            <h3>Area Attacks</h3>
+                            <h3 style="color: #00BFFF">Area Attacks</h3>
                             <p>Let you hit an area rather than a specific target</p>
                         </div>
                         <div class="grid-item special-grid-item">

--- a/executable/remote_server_setup.txt
+++ b/executable/remote_server_setup.txt
@@ -12,7 +12,8 @@ rsync -avzP -e "ssh -i Documents/developer_creds/drudgeford_key.pem" \
 --include="main.py" \
 --include="my_resource.pyxres" \
 --include="requirements.txt" \
---include="banana/***" \
+--include="banana/" \
+--include="banana/drudgeford.dmg" \
 --exclude="**/__pycache__/**" \
 --exclude="**/.pytest_cache/**" \
 --exclude="*" \


### PR DESCRIPTION
- only copy files we need to remote server rather than whole banana directory
- fixing some things in the executable_packaging.py script
- fixing coloring of area attacks in lobby text